### PR TITLE
Fix for :empty

### DIFF
--- a/cssselect/tests.py
+++ b/cssselect/tests.py
@@ -344,9 +344,9 @@ class TestCssselect(unittest.TestCase):
         assert xpath('e:only-of-type') == (
             "e[last() = 1]")
         assert xpath('e:empty') == (
-            "e[not(*) and not(normalize-space())]")
+            "e[not(*) and not(string-length())]")
         assert xpath('e:EmPTY') == (
-            "e[not(*) and not(normalize-space())]")
+            "e[not(*) and not(string-length())]")
         assert xpath('e:root') == (
             "e[not(parent::*)]")
         assert xpath('e:hover') == (
@@ -575,7 +575,7 @@ class TestCssselect(unittest.TestCase):
         assert pcss('p:only-of-type') == ['paragraph']
         assert pcss('a:empty', 'a:EMpty') == ['name-anchor']
         assert pcss('li:empty') == [
-            'third-li', 'fourth-li', 'fifth-li', 'sixth-li', 'seventh-li']
+            'third-li', 'fourth-li', 'fifth-li', 'sixth-li']
         assert pcss(':root', 'html:root') == ['html']
         assert pcss('li:root', '* :root') == []
         assert pcss('*:contains("link")', ':CONtains("link")') == [

--- a/cssselect/xpath.py
+++ b/cssselect/xpath.py
@@ -454,7 +454,7 @@ class GenericTranslator(object):
         return xpath.add_condition('last() = 1')
 
     def xpath_empty_pseudo(self, xpath):
-        return xpath.add_condition("not(*) and not(normalize-space())")
+        return xpath.add_condition("not(*) and not(string-length())")
 
     def pseudo_never_matches(self, xpath):
         """Common implementation for pseudo-classes that never match."""


### PR DESCRIPTION
Now just checking whether the matched non-element node has a (possibly coerced) string-length() > 0.

``` xml
<test>
    <p>          </p>
    <q></q>
    <r><![CDATA[]]></r>
    <![CDATA[abcdef]]>
</test>
```

In this case on this document `:empty` would return `<q></q>` and `<r><![CDATA[]]></r>`.

I believe this is the correct behaviour regarding `CDATA`, but I'm not 100% on that.
