### PR TITLE
Parse |ident as ident

### DIFF
--- a/cssselect/parser.py
+++ b/cssselect/parser.py
@@ -390,6 +390,9 @@ def parse_simple_selector(stream, inside_negation=False):
         elif peek == ('DELIM', '.'):
             stream.next()
             result = Class(result, stream.next_ident())
+        elif peek == ('DELIM', '|'):
+            stream.next()
+            result = Element(None, stream.next_ident())
         elif peek == ('DELIM', '['):
             stream.next()
             result = parse_attrib(result, stream)

--- a/cssselect/tests.py
+++ b/cssselect/tests.py
@@ -79,6 +79,7 @@ class TestCssselect(unittest.TestCase):
         assert parse_many('*') == ['Element[*]']
         assert parse_many('*|*') == ['Element[*]']
         assert parse_many('*|foo') == ['Element[foo]']
+        assert parse_many('|foo') == ['Element[foo]']
         assert parse_many('foo|*') == ['Element[foo|*]']
         assert parse_many('foo|bar') == ['Element[foo|bar]']
         # This will never match, but it is valid:


### PR DESCRIPTION
This is just a quick fix for #9.

The namespace implementation would need a working over to do this properly.

This will make it so that `*|E` `E` and `|E` are the same. Better than a parsing error but not ideal.
