### PR TITLE
Remove XPath string() conversion of element in CSS "contains" function translation

### DIFF
--- a/cssselect/tests.py
+++ b/cssselect/tests.py
@@ -352,9 +352,9 @@ class TestCssselect(unittest.TestCase):
         assert xpath('e:hover') == (
             "e[0]")  # never matches
         assert xpath('e:contains("foo")') == (
-            "e[contains(string(.), 'foo')]")
+            "e[contains(., 'foo')]")
         assert xpath('e:ConTains(foo)') == (
-            "e[contains(string(.), 'foo')]")
+            "e[contains(., 'foo')]")
         assert xpath('e.warning') == (
             "e[@class and contains("
                "concat(' ', normalize-space(@class), ' '), ' warning ')]")

--- a/cssselect/xpath.py
+++ b/cssselect/xpath.py
@@ -417,7 +417,7 @@ class GenericTranslator(object):
                 % function.arguments)
         value = function.arguments[0].value
         return xpath.add_condition(
-            'contains(string(.), %s)' % self.xpath_literal(value))
+            'contains(., %s)' % self.xpath_literal(value))
 
     def xpath_lang_function(self, xpath, function):
         if function.argument_types() not in (['STRING'], ['IDENT']):


### PR DESCRIPTION
According to http://www.w3.org/TR/xpath/#section-Function-Calls (and in practice using `lxml`), each argument is "converted (...) to the type required by the function,".

So, the `string(.)` conversion on the context node is redundant.
Very minor, and probably only cosmetic.
