### PR TITLE
Travis-CI config: remove Python 3.1, add Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
   - "2.5"
   - "2.6"
   - "2.7"
-  - "3.1"
   - "3.2"
+  - "3.3"
 
 install:
   - pip install --use-mirrors lxml -e .


### PR DESCRIPTION
Python 3.1 not supported anymore in Travis
http://about.travis-ci.org/docs/user/ci-environment/#Python-VM-images
