### PR TITLE
Fix exception message in functional pseudo-element test example

### DIFF
--- a/cssselect/tests.py
+++ b/cssselect/tests.py
@@ -451,7 +451,7 @@ class TestCssselect(unittest.TestCase):
                     if not method:
                         raise ExpressionError(
                             "The functional pseudo-element ::%s() is unknown"
-                        % functional.name)
+                        % pseudo_element.name)
                     xpath = method(xpath, pseudo_element.arguments)
                 else:
                     method = 'xpath_%s_simple_pseudo_element' % (


### PR DESCRIPTION
To prevent

```
exceptions.NameError: global name 'functional' is not defined
```

when you copy paste the example test without checking
