### PR TITLE
Fix tox.ini for Python 2.5

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,3 +4,7 @@ envlist = py24,py25,py26,py27,py31,py32,py33
 [testenv]
 deps=lxml
 commands = python cssselect/tests.py
+
+[testenv:py25]
+setenv =
+    PIP_INSECURE = 1


### PR DESCRIPTION
See https://bitbucket.org/hpk42/tox/issue/117/tox-160-breaks-when-running-tests-under

Similar fix for Python 3.1 doesn't work for me.
