### PR TITLE
Remove Python 2.5 as Travis CI Py2.5 support ended

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "2.5"
   - "2.6"
   - "2.7"
   - "3.2"


### PR DESCRIPTION
See http://blog.travis-ci.com/2013-11-18-upcoming-build-environment-updates/
and https://github.com/travis-ci/travis-ci/issues/1668#issuecomment-29151484

Current supported versions:
- 2.6
- 2.7
- 3.2
- 3.3
- 3.4
- pypy

(Source: http://docs.travis-ci.com/user/ci-environment/#Python-VM-images)
