### PR TITLE
Normalize source code encoding

### DIFF
--- a/cssselect/__init__.py
+++ b/cssselect/__init__.py
@@ -1,4 +1,4 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
 """
     CSS Selectors based on XPath
     ============================

--- a/cssselect/parser.py
+++ b/cssselect/parser.py
@@ -1,4 +1,4 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
 """
     cssselect.parser
     ================

--- a/cssselect/tests.py
+++ b/cssselect/tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# coding: utf-8
+# -*- coding: utf-8 -*-
 """
     Tests for cssselect
     ===================

--- a/cssselect/xpath.py
+++ b/cssselect/xpath.py
@@ -1,4 +1,4 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
 """
     cssselect.xpath
     ===============
@@ -108,7 +108,7 @@ class GenericTranslator(object):
     of element names and attribute names.
 
     """
-    
+
     ####
     ####  HERE BE DRAGONS
     ####

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
 
 import re
 import os.path


### PR DESCRIPTION
Related to #54

I don't think it's really a fix since `# coding: utf8` seems fine to me when reading [PEP 263](https://www.python.org/dev/peps/pep-0263/)
but I'm following
https://docs.python.org/3/tutorial/interpreter.html#source-code-encoding
https://docs.python.org/2/tutorial/interpreter.html#source-code-encoding