### PR TITLE
Fix :nth-*(an+b) pseudo-classes selectors

### DIFF
--- a/cssselect/xpath.py
+++ b/cssselect/xpath.py
@@ -441,23 +441,22 @@ class GenericTranslator(object):
         if a == 0:
             return xpath.add_condition('%s = %s' % (siblings_count, b))
 
-        # special case for operations modulo 1
+        # operations modulo 1 or -1 are simpler, one only needs to verify:
+        # count(...) - (b-1) = 0, 1, 2, 3, etc., i.e. count(...) >= (b-1)
+        # or
+        # count(...) - (b-1) = 0, -1, -2, -3, etc., , i.e. count(...) <= (b-1)
         if abs(a) == 1:
             expr = []
         else:
             # count(...) - (b-1) ≡ 0 (mod a)
             left = siblings_count
-            b_neg = -b
 
-            # this is to simplify things like "(... +3) % -3"
-            if a != 0:
-                b_neg = b_neg % abs(a)
+            # use modulo on 2nd term -(b-1) to simplify things like "(... +6) % -3",
+            # and also make it positive with |a|
+            b_neg = (-b) % abs(a)
 
             if b_neg != 0:
-                if b_neg < 0:
-                    b_neg = str(b_neg)
-                else:
-                    b_neg = '+%s' % (b_neg)
+                b_neg = '+%s' % (b_neg)
                 left = '(%s %s)' % (left, b_neg)
 
             expr = ['%s mod %s = 0' % (left, a)]

--- a/cssselect/xpath.py
+++ b/cssselect/xpath.py
@@ -462,8 +462,8 @@ class GenericTranslator(object):
             expr = ['%s mod %s = 0' % (left, a)]
 
         if a > 0:
-            # siblings count is always > 0
-            # so the following predicate only matter for b > 0
+            # siblings count is always >= 0,
+            # so the following predicate only matters for b > 0
             if b > 0:
                 expr.append('%s >= %s' % (siblings_count, b))
         else:

--- a/cssselect/xpath.py
+++ b/cssselect/xpath.py
@@ -351,7 +351,7 @@ class GenericTranslator(object):
 
     def xpath_descendant_combinator(self, left, right):
         """right is a child, grand-child or further descendant of left"""
-        return left.join('/descendant-or-self::*/', right)
+        return left.join('/descendant::', right)
 
     def xpath_child_combinator(self, left, right):
         """right is an immediate child of left"""
@@ -383,11 +383,8 @@ class GenericTranslator(object):
         # nth_of_type() calls nth_child(add_name_test=False)
         if add_name_test:
             nodetest = '*'
-            xpath.add_name_test()
         else:
             nodetest  = '%s' % xpath.element
-
-        xpath.add_star_prefix()
 
         # From https://www.w3.org/TR/css3-selectors/#structural-pseudos:
         #
@@ -522,39 +519,31 @@ class GenericTranslator(object):
         return xpath.add_condition("not(parent::*)")
 
     def xpath_first_child_pseudo(self, xpath):
-        xpath.add_star_prefix()
-        xpath.add_name_test()
-        return xpath.add_condition('position() = 1')
+        return xpath.add_condition('count(preceding-sibling::*) = 0')
 
     def xpath_last_child_pseudo(self, xpath):
-        xpath.add_star_prefix()
-        xpath.add_name_test()
-        return xpath.add_condition('position() = last()')
+        return xpath.add_condition('count(following-sibling::*) = 0')
 
     def xpath_first_of_type_pseudo(self, xpath):
         if xpath.element == '*':
             raise ExpressionError(
                 "*:first-of-type is not implemented")
-        xpath.add_star_prefix()
-        return xpath.add_condition('position() = 1')
+        return xpath.add_condition('count(preceding-sibling::%s) = 0' % xpath.element)
 
     def xpath_last_of_type_pseudo(self, xpath):
         if xpath.element == '*':
             raise ExpressionError(
                 "*:last-of-type is not implemented")
-        xpath.add_star_prefix()
-        return xpath.add_condition('position() = last()')
+        return xpath.add_condition('count(following-sibling::%s) = 0' % xpath.element)
 
     def xpath_only_child_pseudo(self, xpath):
-        xpath.add_name_test()
-        xpath.add_star_prefix()
-        return xpath.add_condition('last() = 1')
+        return xpath.add_condition('count(parent::*/child::*) = 1')
 
     def xpath_only_of_type_pseudo(self, xpath):
         if xpath.element == '*':
             raise ExpressionError(
                 "*:only-of-type is not implemented")
-        return xpath.add_condition('last() = 1')
+        return xpath.add_condition('count(parent::*/child::%s) = 1' % xpath.element)
 
     def xpath_empty_pseudo(self, xpath):
         return xpath.add_condition("not(*) and not(string-length())")

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -347,9 +347,15 @@ class TestCssselect(unittest.TestCase):
         assert xpath('e:nth-last-child(2n)') == (
             "*/*[name() = 'e' and ("
                "(last() - position() +1) mod 2 = 0 and (position() <= last() +1))]")
+        assert xpath('e:nth-last-child(2n+1)') == (
+            "*/*[name() = 'e' and ("
+               "(last() - position()) mod 2 = 0 and (position() <= last()))]")
         assert xpath('e:nth-last-child(2n+2)') == (
             "*/*[name() = 'e' and ("
                "(last() - position() -1) mod 2 = 0 and (position() <= last() -1))]")
+        assert xpath('e:nth-last-child(3n+1)') == (
+            "*/*[name() = 'e' and ("
+               "(last() - position()) mod 3 = 0 and (position() <= last()))]")
         # represents the two last e elements
         assert xpath('e:nth-last-child(-n+2)') == (
             "*/*[name() = 'e' and ("
@@ -661,8 +667,12 @@ class TestCssselect(unittest.TestCase):
         assert pcss('li:nth-last-child(1)') == ['seventh-li']
         assert pcss('li:nth-last-child(2n)', 'li:nth-last-child(even)') == [
             'second-li', 'fourth-li', 'sixth-li']
+        assert pcss('li:nth-last-child(2n+1)') == [
+            'first-li', 'third-li', 'fifth-li', 'seventh-li']
         assert pcss('li:nth-last-child(2n+2)') == [
             'second-li', 'fourth-li', 'sixth-li']
+        assert pcss('li:nth-last-child(3n+1)') == [
+            'first-li', 'fourth-li', 'seventh-li']
         assert pcss('ol:first-of-type') == ['first-ol']
         assert pcss('ol:nth-child(1)') == []
         assert pcss('ol:nth-of-type(2)') == ['second-ol']

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -334,15 +334,37 @@ class TestCssselect(unittest.TestCase):
         assert xpath('e[hreflang|="en"]') == (
             "e[@hreflang and ("
                "@hreflang = 'en' or starts-with(@hreflang, 'en-'))]")
+
+        # --- nth-* and nth-last-* -------------------------------------
         assert xpath('e:nth-child(1)') == (
             "e[count(preceding-sibling::*) = 0]")
+
+        # always true
+        assert xpath('e:nth-child(n)') == (
+            "e")
+        assert xpath('e:nth-child(n+1)') == (
+            "e")
+        # always true too
+        assert xpath('e:nth-child(n-10)') == (
+            "e")
+        # b=2 is the limit...
+        assert xpath('e:nth-child(n+2)') == (
+            "e[count(preceding-sibling::*) >= 1]")
+        # always false
+        assert xpath('e:nth-child(-n)') == (
+            "e[0]")
+        # equivalent to first child
+        assert xpath('e:nth-child(-n+1)') == (
+            "e[count(preceding-sibling::*) <= 0]")
+
         assert xpath('e:nth-child(3n+2)') == (
-            "e[(count(preceding-sibling::*) +2) mod 3 = 0 and "
-              "count(preceding-sibling::*) >= 1]")
+            "e[count(preceding-sibling::*) >= 1 and "
+              "(count(preceding-sibling::*) +2) mod 3 = 0]")
         assert xpath('e:nth-child(3n-2)') == (
             "e[count(preceding-sibling::*) mod 3 = 0]")
         assert xpath('e:nth-child(-n+6)') == (
             "e[count(preceding-sibling::*) <= 5]")
+
         assert xpath('e:nth-last-child(1)') == (
             "e[count(following-sibling::*) = 0]")
         assert xpath('e:nth-last-child(2n)') == (
@@ -350,13 +372,14 @@ class TestCssselect(unittest.TestCase):
         assert xpath('e:nth-last-child(2n+1)') == (
             "e[count(following-sibling::*) mod 2 = 0]")
         assert xpath('e:nth-last-child(2n+2)') == (
-            "e[(count(following-sibling::*) +1) mod 2 = 0 and "
-              "count(following-sibling::*) >= 1]")
+            "e[count(following-sibling::*) >= 1 and "
+              "(count(following-sibling::*) +1) mod 2 = 0]")
         assert xpath('e:nth-last-child(3n+1)') == (
             "e[count(following-sibling::*) mod 3 = 0]")
         # represents the two last e elements
         assert xpath('e:nth-last-child(-n+2)') == (
             "e[count(following-sibling::*) <= 1]")
+
         assert xpath('e:nth-of-type(1)') == (
             "e[count(preceding-sibling::e) = 0]")
         assert xpath('e:nth-last-of-type(1)') == (
@@ -365,6 +388,7 @@ class TestCssselect(unittest.TestCase):
             "div/descendant::e[count(following-sibling::e) = 0]"
                "/descendant::*[@class and contains("
                "concat(' ', normalize-space(@class), ' '), ' aclass ')]")
+
         assert xpath('e:first-child') == (
             "e[count(preceding-sibling::*) = 0]")
         assert xpath('e:last-child') == (
@@ -648,6 +672,16 @@ class TestCssselect(unittest.TestCase):
         assert pcss(':lang("EN")', '*:lang(en-US)', html_only=True) == [
             'second-li', 'li-div']
         assert pcss(':lang("e")', html_only=True) == []
+
+        # --- nth-* and nth-last-* -------------------------------------
+
+        # select nothing
+        assert pcss('li:nth-child(-n)') == []
+        # select all children
+        assert pcss('li:nth-child(n)') == [
+            'first-li', 'second-li', 'third-li', 'fourth-li',
+            'fifth-li', 'sixth-li', 'seventh-li']
+
         assert pcss('li:nth-child(3)',
                     '#first-li ~ :nth-child(3)') == ['third-li']
         assert pcss('li:nth-child(10)') == []

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -335,51 +335,48 @@ class TestCssselect(unittest.TestCase):
             "e[@hreflang and ("
                "@hreflang = 'en' or starts-with(@hreflang, 'en-'))]")
         assert xpath('e:nth-child(1)') == (
-            "*/*[name() = 'e' and (count(preceding-sibling::*) = 0)]")
+            "e[count(preceding-sibling::*) = 0]")
         assert xpath('e:nth-child(3n+2)') == (
-            "*/*[name() = 'e' and ("
-                "(count(preceding-sibling::*) +2) mod 3 = 0 and "
-                 "count(preceding-sibling::*) >= 1)]")
+            "e[(count(preceding-sibling::*) +2) mod 3 = 0 and "
+              "count(preceding-sibling::*) >= 1]")
         assert xpath('e:nth-child(3n-2)') == (
-            "*/*[name() = 'e' and ("
-                "count(preceding-sibling::*) mod 3 = 0)]")
+            "e[count(preceding-sibling::*) mod 3 = 0]")
         assert xpath('e:nth-child(-n+6)') == (
-            "*/*[name() = 'e' and (count(preceding-sibling::*) <= 5)]")
+            "e[count(preceding-sibling::*) <= 5]")
         assert xpath('e:nth-last-child(1)') == (
-            "*/*[name() = 'e' and (count(following-sibling::*) = 0)]")
+            "e[count(following-sibling::*) = 0]")
         assert xpath('e:nth-last-child(2n)') == (
-            "*/*[name() = 'e' and ((count(following-sibling::*) +1) mod 2 = 0)]")
+            "e[(count(following-sibling::*) +1) mod 2 = 0]")
         assert xpath('e:nth-last-child(2n+1)') == (
-            "*/*[name() = 'e' and (count(following-sibling::*) mod 2 = 0)]")
+            "e[count(following-sibling::*) mod 2 = 0]")
         assert xpath('e:nth-last-child(2n+2)') == (
-            "*/*[name() = 'e' and ("
-                "(count(following-sibling::*) +1) mod 2 = 0 and "
-                 "count(following-sibling::*) >= 1)]")
+            "e[(count(following-sibling::*) +1) mod 2 = 0 and "
+              "count(following-sibling::*) >= 1]")
         assert xpath('e:nth-last-child(3n+1)') == (
-            "*/*[name() = 'e' and (count(following-sibling::*) mod 3 = 0)]")
+            "e[count(following-sibling::*) mod 3 = 0]")
         # represents the two last e elements
         assert xpath('e:nth-last-child(-n+2)') == (
-            "*/*[name() = 'e' and (count(following-sibling::*) <= 1)]")
+            "e[count(following-sibling::*) <= 1]")
         assert xpath('e:nth-of-type(1)') == (
-            "*/e[count(preceding-sibling::e) = 0]")
+            "e[count(preceding-sibling::e) = 0]")
         assert xpath('e:nth-last-of-type(1)') == (
-            "*/e[count(following-sibling::e) = 0]")
+            "e[count(following-sibling::e) = 0]")
         assert xpath('div e:nth-last-of-type(1) .aclass') == (
-            "div/descendant-or-self::*/e[count(following-sibling::e) = 0]"
-               "/descendant-or-self::*/*[@class and contains("
+            "div/descendant::e[count(following-sibling::e) = 0]"
+               "/descendant::*[@class and contains("
                "concat(' ', normalize-space(@class), ' '), ' aclass ')]")
         assert xpath('e:first-child') == (
-            "*/*[name() = 'e' and (position() = 1)]")
+            "e[count(preceding-sibling::*) = 0]")
         assert xpath('e:last-child') == (
-            "*/*[name() = 'e' and (position() = last())]")
+            "e[count(following-sibling::*) = 0]")
         assert xpath('e:first-of-type') == (
-            "*/e[position() = 1]")
+            "e[count(preceding-sibling::e) = 0]")
         assert xpath('e:last-of-type') == (
-            "*/e[position() = last()]")
+            "e[count(following-sibling::e) = 0]")
         assert xpath('e:only-child') == (
-            "*/*[name() = 'e' and (last() = 1)]")
+            "e[count(parent::*/child::*) = 1]")
         assert xpath('e:only-of-type') == (
-            "e[last() = 1]")
+            "e[count(parent::*/child::e) = 1]")
         assert xpath('e:empty') == (
             "e[not(*) and not(string-length())]")
         assert xpath('e:EmPTY') == (
@@ -402,7 +399,7 @@ class TestCssselect(unittest.TestCase):
         assert xpath('e:nOT(*)') == (
             "e[0]")  # never matches
         assert xpath('e f') == (
-            "e/descendant-or-self::*/f")
+            "e/descendant::f")
         assert xpath('e > f') == (
             "e/f")
         assert xpath('e + f') == (
@@ -410,9 +407,9 @@ class TestCssselect(unittest.TestCase):
         assert xpath('e ~ f') == (
             "e/following-sibling::f")
         assert xpath('e ~ f:nth-child(3)') == (
-            "e/following-sibling::*[name() = 'f' and (count(preceding-sibling::*) = 2)]")
+            "e/following-sibling::f[count(preceding-sibling::*) = 2]")
         assert xpath('div#container p') == (
-            "div[@id = 'container']/descendant-or-self::*/p")
+            "div[@id = 'container']/descendant::p")
 
         # Invalid characters in XPath element names
         assert xpath(r'di\a0 v') == (
@@ -538,7 +535,7 @@ class TestCssselect(unittest.TestCase):
         assert xpath('::text-node') == "descendant-or-self::*/text()"
         assert xpath('::attr-href') == "descendant-or-self::*/@href"
         assert xpath('p img::attr(src)') == (
-            "descendant-or-self::p/descendant-or-self::*/img/@src")
+            "descendant-or-self::p/descendant::img/@src")
 
     def test_series(self):
         def series(css):

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -657,7 +657,6 @@ class TestCssselect(unittest.TestCase):
         assert pcss('li:nth-child(+2n+1)', 'li:nth-child(odd)') == [
             'first-li', 'third-li', 'fifth-li', 'seventh-li']
         assert pcss('li:nth-child(2n+4)') == ['fourth-li', 'sixth-li']
-        # FIXME: I'm not 100% sure this is right:
         assert pcss('li:nth-child(3n+1)') == [
             'first-li', 'fourth-li', 'seventh-li']
         assert pcss('li:nth-child(-n+3)') == [

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -336,19 +336,30 @@ class TestCssselect(unittest.TestCase):
                "@hreflang = 'en' or starts-with(@hreflang, 'en-'))]")
         assert xpath('e:nth-child(1)') == (
             "*/*[name() = 'e' and (position() = 1)]")
+        assert xpath('e:nth-child(3n+2)') == (
+            "*/*[name() = 'e' and ((position() -2) mod 3 = 0 and position() >= 2)]")
+        assert xpath('e:nth-child(3n-2)') == (
+            "*/*[name() = 'e' and ((position() +2) mod 3 = 0)]")
+        assert xpath('e:nth-child(-n+6)') == (
+            "*/*[name() = 'e' and ((position() -6) mod -1 = 0 and position() <= 6)]")
         assert xpath('e:nth-last-child(1)') == (
-            "*/*[name() = 'e' and (position() = last() - 1)]")
+            "*/*[name() = 'e' and (position() = last())]")
+        assert xpath('e:nth-last-child(2n)') == (
+            "*/*[name() = 'e' and ("
+               "(last() - position() +1) mod 2 = 0 and (position() <= last() +1))]")
         assert xpath('e:nth-last-child(2n+2)') == (
             "*/*[name() = 'e' and ("
-               "(position() +2) mod -2 = 0 and position() < (last() -2))]")
+               "(last() - position() -1) mod 2 = 0 and (position() <= last() -1))]")
+        # represents the two last e elements
+        assert xpath('e:nth-last-child(-n+2)') == (
+            "*/*[name() = 'e' and ("
+               "(last() - position() -1) mod -1 = 0 and (position() >= last() -1))]")
         assert xpath('e:nth-of-type(1)') == (
             "*/e[position() = 1]")
         assert xpath('e:nth-last-of-type(1)') == (
-            "*/e[position() = last() - 1]")
-        assert xpath('e:nth-last-of-type(1)') == (
-            "*/e[position() = last() - 1]")
+            "*/e[position() = last()]")
         assert xpath('div e:nth-last-of-type(1) .aclass') == (
-            "div/descendant-or-self::*/e[position() = last() - 1]"
+            "div/descendant-or-self::*/e[position() = last()]"
                "/descendant-or-self::*/*[@class and contains("
                "concat(' ', normalize-space(@class), ' '), ' aclass ')]")
         assert xpath('e:first-child') == (
@@ -381,7 +392,7 @@ class TestCssselect(unittest.TestCase):
         assert xpath('e#myid') == (
             "e[@id = 'myid']")
         assert xpath('e:not(:nth-child(odd))') == (
-            "e[not((position() -1) mod 2 = 0 and position() >= 1)]")
+            "e[not((position() -1) mod 2 = 0)]")
         assert xpath('e:nOT(*)') == (
             "e[0]")  # never matches
         assert xpath('e f') == (
@@ -643,16 +654,19 @@ class TestCssselect(unittest.TestCase):
         # FIXME: I'm not 100% sure this is right:
         assert pcss('li:nth-child(3n+1)') == [
             'first-li', 'fourth-li', 'seventh-li']
-        assert pcss('li:nth-last-child(0)') == [
-            'seventh-li']
+        assert pcss('li:nth-child(-n+3)') == [
+            'first-li', 'second-li', 'third-li']
+        assert pcss('li:nth-child(-2n+4)') == ['second-li', 'fourth-li']
+        assert pcss('li:nth-last-child(0)') == []
+        assert pcss('li:nth-last-child(1)') == ['seventh-li']
         assert pcss('li:nth-last-child(2n)', 'li:nth-last-child(even)') == [
             'second-li', 'fourth-li', 'sixth-li']
-        assert pcss('li:nth-last-child(2n+2)') == ['second-li', 'fourth-li']
+        assert pcss('li:nth-last-child(2n+2)') == [
+            'second-li', 'fourth-li', 'sixth-li']
         assert pcss('ol:first-of-type') == ['first-ol']
         assert pcss('ol:nth-child(1)') == []
         assert pcss('ol:nth-of-type(2)') == ['second-ol']
-        # FIXME: like above', '(1) or (2)?
-        assert pcss('ol:nth-last-of-type(1)') == ['first-ol']
+        assert pcss('ol:nth-last-of-type(1)') == ['second-ol']
         assert pcss('span:only-child') == ['foobar-span']
         assert pcss('li div:only-child') == ['li-div']
         assert pcss('div *:only-child') == ['li-div', 'foobar-span']


### PR DESCRIPTION
This is a continuation of https://github.com/scrapy/cssselect/pull/42 but following https://www.w3.org/TR/css3-selectors/#structural-pseudos definitions more closely, that is, counting `preceding-sibling::` or `following-sibling::` explicitly, instead of using context-dependent `position()`:

> :nth-child() pseudo-class
> The :nth-child(an+b) pseudo-class notation represents an element that has an+b-1 siblings before it in the document tree 

In fact, this was suggested in https://github.com/sparklemotion/nokogiri/issues/707#issuecomment-11141106.

It fixes https://github.com/scrapy/cssselect/issues/12, https://github.com/scrapy/cssselect/issues/15, https://github.com/scrapy/cssselect/issues/46.

Another change is `xpath_descendant_combinator` which now translates to `/descendant` (instead of  `/descendant-or-self`), which looks more inline with [Descendant combinator](https://www.w3.org/TR/css3-selectors/#descendant-combinators):

> A selector of the form "A B" represents an element B that is an arbitrary descendant of some ancestor element A.

[The general case](https://github.com/sparklemotion/nokogiri/issues/707#issuecomment-11141897) of `h2 ~ *:nth-of-type(2)` is not fixed by this PR. It looks hard (or impossible) to achieve with XPath 1.0 alone, but it may not be that common case.