### PR TITLE
Drop Python 3.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
@@ -11,9 +10,6 @@ python:
 install:
   - pip install lxml -e .
   - pip install -U codecov pytest-cov
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]];
-    then pip uninstall -y coverage pytest && pip install "coverage<4" && pip install "pytest<3";
-    fi
 
 script:
   py.test --cov-report term --cov=cssselect

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',


### PR DESCRIPTION
This started as a fix for Travis-CI builds and py.test>=3.0
See http://doc.pytest.org/en/latest/changelog.html
and https://github.com/pytest-dev/pytest/pull/1627

But we might as well drop python 3.2 support as it's not very commonly used.
See https://github.com/pypa/pip/issues/3796

An alternative is to force py.test<3.0: https://github.com/scrapy/cssselect/pull/62