### PR TITLE
Force py.test version before 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   - pip install lxml -e .
   - pip install -U codecov pytest-cov
   - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]];
-    then pip uninstall -y coverage && pip install "coverage<4";
+    then pip uninstall -y coverage pytest && pip install "coverage<4" && pip install "pytest<3";
     fi
 
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py25,py26,py27,py32,py33
 [testenv]
 deps=
     lxml
-    pytest
+    pytest<3
     pytest-cov
 
 commands =


### PR DESCRIPTION
py.test 3.0 dropped support for Python 3.2
https://github.com/pytest-dev/pytest/issues/1627