### PR TITLE
Revert descendant combinator change

### DIFF
--- a/cssselect/xpath.py
+++ b/cssselect/xpath.py
@@ -351,7 +351,7 @@ class GenericTranslator(object):
 
     def xpath_descendant_combinator(self, left, right):
         """right is a child, grand-child or further descendant of left"""
-        return left.join('/descendant::', right)
+        return left.join('/descendant-or-self::*/', right)
 
     def xpath_child_combinator(self, left, right):
         """right is an immediate child of left"""

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -385,8 +385,8 @@ class TestCssselect(unittest.TestCase):
         assert xpath('e:nth-last-of-type(1)') == (
             "e[count(following-sibling::e) = 0]")
         assert xpath('div e:nth-last-of-type(1) .aclass') == (
-            "div/descendant::e[count(following-sibling::e) = 0]"
-               "/descendant::*[@class and contains("
+            "div/descendant-or-self::*/e[count(following-sibling::e) = 0]"
+               "/descendant-or-self::*/*[@class and contains("
                "concat(' ', normalize-space(@class), ' '), ' aclass ')]")
 
         assert xpath('e:first-child') == (
@@ -423,7 +423,7 @@ class TestCssselect(unittest.TestCase):
         assert xpath('e:nOT(*)') == (
             "e[0]")  # never matches
         assert xpath('e f') == (
-            "e/descendant::f")
+            "e/descendant-or-self::*/f")
         assert xpath('e > f') == (
             "e/f")
         assert xpath('e + f') == (
@@ -433,7 +433,7 @@ class TestCssselect(unittest.TestCase):
         assert xpath('e ~ f:nth-child(3)') == (
             "e/following-sibling::f[count(preceding-sibling::*) = 2]")
         assert xpath('div#container p') == (
-            "div[@id = 'container']/descendant::p")
+            "div[@id = 'container']/descendant-or-self::*/p")
 
         # Invalid characters in XPath element names
         assert xpath(r'di\a0 v') == (
@@ -559,7 +559,7 @@ class TestCssselect(unittest.TestCase):
         assert xpath('::text-node') == "descendant-or-self::*/text()"
         assert xpath('::attr-href') == "descendant-or-self::*/@href"
         assert xpath('p img::attr(src)') == (
-            "descendant-or-self::p/descendant::img/@src")
+            "descendant-or-self::p/descendant-or-self::*/img/@src")
 
     def test_series(self):
         def series(css):


### PR DESCRIPTION
This reverts the change to `xpath_descendant_combinator` from https://github.com/scrapy/cssselect/pull/60/commits/d86287dc211b5b75c549aa2febb0ad4ece0ead02 so as to keep backwards compatiblity with cssselect-dependent libraries like parsel (see https://github.com/scrapy/cssselect/pull/61#issuecomment-246354238 and subsequent comments)

`/descendant::` and `/descendant-or-self::*/` are essentially equivalent in practice for the translation when only elements are involved. But for custom pseudo-elements like parsel does with `::text` and `::attr(name)`, [which need a bit of hacking of the translated path](https://github.com/scrapy/parsel/blob/04e6e145ce6ad964435225fc953be15f6e1b6d1a/parsel/csstranslator.py#L25), it's probably safer to keep the "long" version.

/cc @kmike 