### PR TITLE
Move docs to ReadTheDocs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Quick facts:
 
 * Free software: BSD licensed
 * Compatible with Python 2.6+ and 3.3+
-* Latest documentation `on python.org <https://pythonhosted.org/cssselect/>`_
+* Latest documentation `on Read the Docs <https://cssselect.readthedocs.io/>`_
 * Source, issues and pull requests `on Github
   <https://github.com/scrapy/cssselect>`_
 * Releases `on PyPI <http://pypi.python.org/pypi/cssselect>`_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'cssselect'
-copyright = '2012, Simon Sapin'
+copyright = '2012-2017, Simon Sapin, Scrapy developers'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     description=
         'cssselect parses CSS3 Selectors and translates them to XPath 1.0',
     long_description=README,
-    url='https://pythonhosted.org/cssselect/',
+    url='https://github.com/scrapy/cssselect',
     license='BSD',
     packages=['cssselect'],
     classifiers=[


### PR DESCRIPTION
Fixes https://github.com/scrapy/cssselect/issues/65
See https://cssselect.readthedocs.io/en/latest/

(I'll then upload a redirection index.html for PyPI/pythonhosted.org as explained in https://github.com/scrapy/cssselect/issues/65#issuecomment-263057732)