### PR TITLE
add a  method on the Selector class, to export back the selector to css

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Simon Sapin
 Stefan Behnel
 Thomas Grainger
 Varialus
+Arthur Darcet

--- a/cssselect/parser.py
+++ b/cssselect/parser.py
@@ -76,7 +76,7 @@ class Selector(object):
         #: +-------------------------+----------------+--------------------------------+
         #: | Invalid pseudo-class    | ``li:marker``  | ``None``                       |
         #: +-------------------------+----------------+--------------------------------+
-        #: | Functinal               | ``a::foo(2)``  | ``FunctionalPseudoElement(…)`` |
+        #: | Functional              | ``a::foo(2)``  | ``FunctionalPseudoElement(…)`` |
         #: +-------------------------+----------------+--------------------------------+
         #:
         #: .. _Lists3: http://www.w3.org/TR/2011/WD-css3-lists-20110524/#marker-pseudoelement
@@ -91,6 +91,20 @@ class Selector(object):
             pseudo_element = ''
         return '%s[%r%s]' % (
             self.__class__.__name__, self.parsed_tree, pseudo_element)
+
+    def css(self):
+        """Return a CSS representation for this selector (a string)
+        """
+        if isinstance(self.pseudo_element, FunctionalPseudoElement):
+            pseudo_element = '::%s' % self.pseudo_element.css()
+        elif self.pseudo_element:
+            pseudo_element = '::%s' % self.pseudo_element
+        else:
+            pseudo_element = ''
+        res = '%s%s' % (self.parsed_tree.css(), pseudo_element)
+        if len(res) > 1:
+            res = res.lstrip('*')
+        return res
 
     def specificity(self):
         """Return the specificity_ of this selector as a tuple of 3 integers.
@@ -115,6 +129,9 @@ class Class(object):
     def __repr__(self):
         return '%s[%r.%s]' % (
             self.__class__.__name__, self.selector, self.class_name)
+
+    def css(self):
+        return '%s.%s' % (self.selector.css(), self.class_name)
 
     def specificity(self):
         a, b, c = self.selector.specificity()
@@ -151,6 +168,10 @@ class FunctionalPseudoElement(object):
     def argument_types(self):
         return [token.type for token in self.arguments]
 
+    def css(self):
+        args = ''.join(token.css() for token in self.arguments)
+        return '%s(%s)' % (self.name, args)
+
     def specificity(self):
         a, b, c = self.selector.specificity()
         b += 1
@@ -174,6 +195,10 @@ class Function(object):
     def argument_types(self):
         return [token.type for token in self.arguments]
 
+    def css(self):
+        args = ''.join(token.css() for token in self.arguments)
+        return '%s:%s(%s)' % (self.selector.css(), self.name, args)
+
     def specificity(self):
         a, b, c = self.selector.specificity()
         b += 1
@@ -192,6 +217,9 @@ class Pseudo(object):
         return '%s[%r:%s]' % (
             self.__class__.__name__, self.selector, self.ident)
 
+    def css(self):
+        return '%s:%s' % (self.selector.css(), self.ident)
+
     def specificity(self):
         a, b, c = self.selector.specificity()
         b += 1
@@ -209,6 +237,10 @@ class Negation(object):
     def __repr__(self):
         return '%s[%r:not(%r)]' % (
             self.__class__.__name__, self.selector, self.subselector)
+
+    def css(self):
+        return '%s:not(%s)' % (self.selector.css(),
+            self.subselector.css())
 
     def specificity(self):
         a1, b1, c1 = self.selector.specificity()
@@ -238,7 +270,20 @@ class Attrib(object):
         else:
             return '%s[%r[%s %s %r]]' % (
                 self.__class__.__name__, self.selector, attrib,
-                self.operator, self.value)
+                self.operator, self.value.value)
+
+    def css(self):
+        if self.namespace:
+            attrib = '%s|%s' % (self.namespace, self.attrib)
+        else:
+            attrib = self.attrib
+
+        if self.operator == 'exists':
+            op = attrib
+        else:
+            op = '%s%s%s' % (attrib, self.operator, self.value.css())
+
+        return '%s[%s]' % (self.selector.css(), op)
 
     def specificity(self):
         a, b, c = self.selector.specificity()
@@ -258,10 +303,13 @@ class Element(object):
         self.element = element
 
     def __repr__(self):
+        return '%s[%s]' % (self.__class__.__name__, self.css())
+
+    def css(self):
         element = self.element or '*'
         if self.namespace:
             element = '%s|%s' % (self.namespace, element)
-        return '%s[%s]' % (self.__class__.__name__, element)
+        return element
 
     def specificity(self):
         if self.element:
@@ -281,6 +329,9 @@ class Hash(object):
     def __repr__(self):
         return '%s[%r#%s]' % (
             self.__class__.__name__, self.selector, self.id)
+
+    def css(self):
+        return '%s#%s' % (self.selector.css(), self.id)
 
     def specificity(self):
         a, b, c = self.selector.specificity()
@@ -302,6 +353,10 @@ class CombinedSelector(object):
             comb = self.combinator
         return '%s[%r %s %r]' % (
             self.__class__.__name__, self.selector, comb, self.subselector)
+
+    def css(self):
+        return '%s %s %s' % (self.selector.css(),
+            self.combinator, self.subselector.css())
 
     def specificity(self):
         a1, b1, c1 = self.selector.specificity()
@@ -536,7 +591,7 @@ def parse_attrib(selector, stream):
     if next != ('DELIM', ']'):
         raise SelectorSyntaxError(
             "Expected ']', got %s" % (next,))
-    return Attrib(selector, namespace, attrib, op, value.value)
+    return Attrib(selector, namespace, attrib, op, value)
 
 
 def parse_series(tokens):
@@ -590,6 +645,12 @@ class Token(tuple):
 
     type = property(operator.itemgetter(0))
     value = property(operator.itemgetter(1))
+
+    def css(self):
+        if self.type == 'STRING':
+            return repr(self.value)
+        else:
+            return self.value
 
 
 class EOFToken(Token):

--- a/cssselect/xpath.py
+++ b/cssselect/xpath.py
@@ -308,10 +308,12 @@ class GenericTranslator(object):
             attrib = '@' + name
         else:
             attrib = 'attribute::*[name() = %s]' % self.xpath_literal(name)
-        if self.lower_case_attribute_values:
-            value = selector.value.lower()
+        if selector.value is None:
+            value = None
+        elif self.lower_case_attribute_values:
+            value = selector.value.value.lower()
         else:
-            value = selector.value
+            value = selector.value.value
         return method(self.xpath(selector.selector), attrib, value)
 
     def xpath_class(self, class_selector):

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -244,6 +244,37 @@ class TestCssselect(unittest.TestCase):
         assert specificity('#lorem + foo#ipsum:first-child > bar:first-line'
             ) == (2, 1, 3)
 
+    def test_css_export(self):
+        def css2css(css, res=None):
+            selectors = parse(css)
+            assert len(selectors) == 1
+            assert selectors[0].css() == (res or css)
+
+        css2css('*')
+        css2css(' foo', 'foo')
+        css2css('Foo', 'Foo')
+        css2css(':empty ', ':empty')
+        css2css(':before', '::before')
+        css2css(':beFOre', '::before')
+        css2css('*:before', '::before')
+        css2css(':nth-child(2)')
+        css2css('.bar')
+        css2css('[baz]')
+        css2css('[baz="4"]', "[baz='4']")
+        css2css('[baz^="4"]', "[baz^='4']")
+        css2css('#lipsum')
+        css2css(':not(*)')
+        css2css(':not(foo)')
+        css2css(':not(*.foo)')
+        css2css(':not(*[foo])')
+        css2css(':not(*:empty)')
+        css2css(':not(*#foo)')
+        css2css('foo:empty')
+        css2css('foo::before')
+        css2css('foo:empty::before')
+        css2css('::name(arg + "val" - 3)', "::name(arg+'val'-3)")
+        css2css('#lorem + foo#ipsum:first-child > bar::first-line')
+
     def test_parse_errors(self):
         def get_error(css):
             try:

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -248,7 +248,7 @@ class TestCssselect(unittest.TestCase):
         def css2css(css, res=None):
             selectors = parse(css)
             assert len(selectors) == 1
-            assert selectors[0].css() == (res or css)
+            assert selectors[0].canonical() == (res or css)
 
         css2css('*')
         css2css(' foo', 'foo')
@@ -262,18 +262,20 @@ class TestCssselect(unittest.TestCase):
         css2css('[baz]')
         css2css('[baz="4"]', "[baz='4']")
         css2css('[baz^="4"]', "[baz^='4']")
+        css2css("[ns|attr='4']")
         css2css('#lipsum')
         css2css(':not(*)')
         css2css(':not(foo)')
-        css2css(':not(*.foo)')
-        css2css(':not(*[foo])')
-        css2css(':not(*:empty)')
-        css2css(':not(*#foo)')
+        css2css(':not(*.foo)', ':not(.foo)')
+        css2css(':not(*[foo])', ':not([foo])')
+        css2css(':not(:empty)')
+        css2css(':not(#foo)')
         css2css('foo:empty')
         css2css('foo::before')
         css2css('foo:empty::before')
         css2css('::name(arg + "val" - 3)', "::name(arg+'val'-3)")
         css2css('#lorem + foo#ipsum:first-child > bar::first-line')
+        css2css('foo > *')
 
     def test_parse_errors(self):
         def get_error(css):


### PR DESCRIPTION
My use case is the following:
 - parse a selector group
 - filter out some rules I don't want
 - export the remaining selectors back to CSS

I have added a `css` method on the `Selector` class (and on each "sub"-selectors), to be able to export them back to CSS