### PR TITLE
Drop support for EOL Python 2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /dist
 /docs/_build
 /.coverage
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - '2.6'
   - '2.7'
   - '3.3'
   - '3.4'

--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,9 @@ extracted as a stand-alone project.
 Quick facts:
 
 * Free software: BSD licensed
-* Compatible with Python 2.6+ and 3.3+
+* Compatible with Python 2.7 and 3.3+
 * Latest documentation `on Read the Docs <https://cssselect.readthedocs.io/>`_
-* Source, issues and pull requests `on Github
+* Source, issues and pull requests `on GitHub
   <https://github.com/scrapy/cssselect>`_
 * Releases `on PyPI <http://pypi.python.org/pypi/cssselect>`_
 * Install with ``pip install cssselect``

--- a/cssselect/parser.py
+++ b/cssselect/parser.py
@@ -552,14 +552,14 @@ def parse_series(tokens):
             raise ValueError('String tokens not allowed in series.')
     s = ''.join(token.value for token in tokens).strip()
     if s == 'odd':
-        return (2, 1)
+        return 2, 1
     elif s == 'even':
-        return (2, 0)
+        return 2, 0
     elif s == 'n':
-        return (1, 0)
+        return 1, 0
     if 'n' not in s:
         # Just b
-        return (0, int(s))
+        return 0, int(s)
     a, b = s.split('n', 1)
     if not a:
         a = 1
@@ -571,7 +571,7 @@ def parse_series(tokens):
         b = 0
     else:
         b = int(b)
-    return (a, b)
+    return a, b
 
 
 #### Token objects

--- a/cssselect/parser.py
+++ b/cssselect/parser.py
@@ -358,8 +358,6 @@ def parse(css):
 #        message = "%s at %s -> %r" % (
 #            e, stream.used, stream.peek())
 #        e.msg = message
-#        if sys.version_info < (2,6):
-#            e.message = message
 #        e.args = tuple([message])
 #        raise
 
@@ -630,12 +628,7 @@ _sub_unicode_escape = re.compile(TokenMacros.unicode_escape, re.I).sub
 _sub_newline_escape =re.compile(r'\\(?:\n|\r\n|\r|\f)').sub
 
 # Same as r'\1', but faster on CPython
-if hasattr(operator, 'methodcaller'):
-    # Python 2.6+
-    _replace_simple = operator.methodcaller('group', 1)
-else:
-    def _replace_simple(match):
-        return match.group(1)
+_replace_simple = operator.methodcaller('group', 1)
 
 def _replace_unicode(match):
     codepoint = int(match.group(1), 16)

--- a/cssselect/xpath.py
+++ b/cssselect/xpath.py
@@ -490,7 +490,7 @@ class GenericTranslator(object):
             b_neg = (-b_min_1) % abs(a)
 
             if b_neg != 0:
-                b_neg = '+%s' % (b_neg)
+                b_neg = '+%s' % b_neg
                 left = '(%s %s)' % (left, b_neg)
 
             expr.append('%s mod %s = 0' % (left, a))

--- a/setup.py
+++ b/setup.py
@@ -29,12 +29,12 @@ setup(
     url='https://github.com/scrapy/cssselect',
     license='BSD',
     packages=['cssselect'],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -288,12 +288,12 @@ class TestCssselect(unittest.TestCase):
             "Expected string or ident, got <DELIM '#' at 5>")
         assert get_error('[href]a') == (
             "Expected selector, got <IDENT 'a' at 6>")
-        assert get_error('[rel=stylesheet]') == None
+        assert get_error('[rel=stylesheet]') is None
         assert get_error('[rel:stylesheet]') == (
             "Operator expected, got <DELIM ':' at 4>")
         assert get_error('[rel=stylesheet') == (
             "Expected ']', got <EOF at 15>")
-        assert get_error(':lang(fr)') == None
+        assert get_error(':lang(fr)') is None
         assert get_error(':lang(fr') == (
             "Expected an argument, got <EOF at 8>")
         assert get_error(':contains("foo') == (
@@ -586,8 +586,8 @@ class TestCssselect(unittest.TestCase):
         assert series('+n') == (1, 0)
         assert series('-n') == (-1, 0)
         assert series('5') == (0, 5)
-        assert series('foo') == None
-        assert series('n+') == None
+        assert series('foo') is None
+        assert series('n+') is None
 
     def test_lang(self):
         document = etree.fromstring(XMLLANG_IDS)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py25,py26,py27,py32,py33
+envlist = py27,py33,py34,py35,py36
 
 [testenv]
 deps=
@@ -9,7 +9,3 @@ deps=
 
 commands =
     py.test --cov-report term --cov=cssselect
-
-[testenv:py25]
-setenv =
-    PIP_INSECURE = 1


### PR DESCRIPTION
Latest master is failing on Python 2.6 because pytest no longer supports it.
https://travis-ci.org/hugovk/cssselect/builds/316469101

It was also suggested to drop it in https://github.com/scrapy/cssselect/pull/61#issuecomment-245896313:

> +1 to drop Python 3.2 and Python 2.6 support. 

Python 2.6 has been EOL for 4 years and hasn't received a security update since then. It's also little used.

Here's the pip installs for cssselect from PyPI for the last month (via `pypinfo --percent --pip --markdown cssselect pyversion`)

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |   63.8% |        145,167 |
| 3.6            |   19.3% |         43,801 |
| 3.5            |   11.3% |         25,618 |
| 3.4            |    5.3% |         12,157 |
| 3.7            |    0.2% |            404 |
| 2.6            |    0.1% |            250 |
| 3.3            |    0.1% |            127 |
| 3.2            |    0.0% |              7 |
| None           |    0.0% |              1 |

---

Python 3.3 is also EOL and even less used. Should that be dropped as well?

