### PR TITLE
[MRG+1] Drop support for EOL Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - '2.7'
-  - '3.3'
   - '3.4'
   - '3.5'
   - '3.6'

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ extracted as a stand-alone project.
 Quick facts:
 
 * Free software: BSD licensed
-* Compatible with Python 2.7 and 3.3+
+* Compatible with Python 2.7 and 3.4+
 * Latest documentation `on Read the Docs <https://cssselect.readthedocs.io/>`_
 * Source, issues and pull requests `on GitHub
   <https://github.com/scrapy/cssselect>`_

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     url='https://github.com/scrapy/cssselect',
     license='BSD',
     packages=['cssselect'],
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
@@ -37,7 +37,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,py36
+envlist = py27, py34, py35, py36
 
 [testenv]
 deps=


### PR DESCRIPTION
Python 3.3 is EOL and no longer receives security updates. It's also little used.

Here's the pip installs for cssselect from PyPI for the last month (via `pypinfo --percent --pip --markdown cssselect pyversion`)

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |   63.8% |        145,167 |
| 3.6            |   19.3% |         43,801 |
| 3.5            |   11.3% |         25,618 |
| 3.4            |    5.3% |         12,157 |
| 3.7            |    0.2% |            404 |
| 2.6            |    0.1% |            250 |
| 3.3            |    0.1% |            127 |
| 3.2            |    0.0% |              7 |
| None           |    0.0% |              1 |

