### PR TITLE
Parse |ident as ident. No longer an error.

### DIFF
--- a/cssselect/parser.py
+++ b/cssselect/parser.py
@@ -430,6 +430,9 @@ def parse_simple_selector(stream, inside_negation=False):
         elif peek == ('DELIM', '.'):
             stream.next()
             result = Class(result, stream.next_ident())
+        elif peek == ('DELIM', '|'):
+            stream.next()
+            result = Element(None, stream.next_ident())
         elif peek == ('DELIM', '['):
             stream.next()
             result = parse_attrib(result, stream)

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -81,6 +81,7 @@ class TestCssselect(unittest.TestCase):
         assert parse_many('*') == ['Element[*]']
         assert parse_many('*|*') == ['Element[*]']
         assert parse_many('*|foo') == ['Element[foo]']
+        assert parse_many('|foo') == ['Element[foo]']
         assert parse_many('foo|*') == ['Element[foo|*]']
         assert parse_many('foo|bar') == ['Element[foo|bar]']
         # This will never match, but it is valid:


### PR DESCRIPTION
Continuation of #21.