### PR TITLE
Fix ID selector syntax

### DIFF
--- a/cssselect/xpath.py
+++ b/cssselect/xpath.py
@@ -326,6 +326,12 @@ class GenericTranslator(object):
     def xpath_hash(self, id_selector):
         """Translate an ID selector."""
         xpath = self.xpath(id_selector.selector)
+        is_valid_identifier = not (re.match('--', id_selector.id)
+                                   or re.match('[0-9]', id_selector.id)
+                                   or re.match('-[0-9]', id_selector.id)
+                                   )
+        if not is_valid_identifier:
+            raise ExpressionError("invalid identifier")
         return self.xpath_attrib_equals(xpath, '@id', id_selector.id)
 
     def xpath_element(self, selector):

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -526,6 +526,9 @@ class TestCssselect(unittest.TestCase):
         self.assertRaises(ExpressionError, xpath, ':lorem-ipsum')
         self.assertRaises(ExpressionError, xpath, ':lorem(ipsum)')
         self.assertRaises(ExpressionError, xpath, '::lorem-ipsum')
+        self.assertRaises(ExpressionError, xpath, '#00FF55')
+        self.assertRaises(ExpressionError, xpath, '#--abc')
+        self.assertRaises(ExpressionError, xpath, '#-1abc')
         self.assertRaises(TypeError, GenericTranslator().css_to_xpath, 4)
         self.assertRaises(TypeError, GenericTranslator().selector_to_xpath,
             'foo')


### PR DESCRIPTION
In issue #24 it is mentioned that https://www.w3.org/TR/CSS21/syndata.html#value-def-identifier says:
> cannot start with a digit, two hyphens, or a hyphen followed by a digit

this pr adds validation for the 3 cases mentioned and raises error. tests are also extended.