### PR TITLE
fix: handle backslash produced by an Unicode hex sequence

### DIFF
--- a/cssselect/parser.py
+++ b/cssselect/parser.py
@@ -938,7 +938,7 @@ _replace_simple = operator.methodcaller("group", 1)
 def _replace_unicode(match: "re.Match[str]") -> str:
     codepoint = int(match.group(1), 16)
     if codepoint == 0x5C:
-        return r'\\'
+        return r"\\"
     if codepoint > sys.maxunicode:
         codepoint = 0xFFFD
     return chr(codepoint)

--- a/cssselect/parser.py
+++ b/cssselect/parser.py
@@ -937,6 +937,8 @@ _replace_simple = operator.methodcaller("group", 1)
 
 def _replace_unicode(match: "re.Match[str]") -> str:
     codepoint = int(match.group(1), 16)
+    if codepoint == 0x5C:
+        return r'\\'
     if codepoint > sys.maxunicode:
         codepoint = 0xFFFD
     return chr(codepoint)

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -562,9 +562,7 @@ class TestCssselect(unittest.TestCase):
         assert css_to_xpath("*[aval=\"'\\20\r\n '\"]") == (
             """descendant-or-self::*[@aval = "'  '"]"""
         )
-        assert css_to_xpath(r'*[aval="\5czz"]') == (
-            r"descendant-or-self::*[@aval = '\zz']"
-        )
+        assert css_to_xpath(r'*[aval="\5czz"]') == (r"descendant-or-self::*[@aval = '\zz']")
         assert css_to_xpath(r'*[aval="foo\5c bar"]') == (
             r"descendant-or-self::*[@aval = 'foo\bar']"
         )

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -562,6 +562,12 @@ class TestCssselect(unittest.TestCase):
         assert css_to_xpath("*[aval=\"'\\20\r\n '\"]") == (
             """descendant-or-self::*[@aval = "'  '"]"""
         )
+        assert css_to_xpath(r'*[aval="\5czz"]') == (
+            r"descendant-or-self::*[@aval = '\zz']"
+        )
+        assert css_to_xpath(r'*[aval="foo\5c bar"]') == (
+            r"descendant-or-self::*[@aval = 'foo\bar']"
+        )
 
     def test_xpath_pseudo_elements(self) -> None:
         class CustomTranslator(GenericTranslator):


### PR DESCRIPTION
Using the Unicode hex sequence `\5c` produces a `\` but it is not escaped. Therefore, it ends up being treated as a simple escape.