### PR TITLE
Remove a deprecated function.

### DIFF
--- a/cssselect/xpath.py
+++ b/cssselect/xpath.py
@@ -14,7 +14,6 @@
 
 import re
 import typing
-import warnings
 from typing import Optional
 
 from cssselect.parser import (
@@ -36,17 +35,6 @@ from cssselect.parser import (
     parse,
     parse_series,
 )
-
-
-@typing.no_type_check
-def _unicode_safe_getattr(obj, name, default=None):
-    warnings.warn(
-        "_unicode_safe_getattr is deprecated and will be removed in the"
-        " next release, use getattr() instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return getattr(obj, name, default)
 
 
 class ExpressionError(SelectorError, RuntimeError):


### PR DESCRIPTION
This was deprecated in 1.2.0, released on 2022-10-27.