### PR TITLE
Fix specificity for :is and :where with a preceding selector

### DIFF
--- a/cssselect/parser.py
+++ b/cssselect/parser.py
@@ -315,7 +315,9 @@ class Matching:
         return f"{self.selector.canonical()}:is({args_str})"
 
     def specificity(self) -> tuple[int, int, int]:
-        return max(x.specificity() for x in self.selector_list)
+        a1, b1, c1 = self.selector.specificity()
+        a2, b2, c2 = max(x.specificity() for x in self.selector_list)
+        return a1 + a2, b1 + b2, c1 + c2
 
 
 class SpecificityAdjustment:
@@ -341,7 +343,7 @@ class SpecificityAdjustment:
         return f"{self.selector.canonical()}:where({args_str})"
 
     def specificity(self) -> tuple[int, int, int]:
-        return 0, 0, 0
+        return self.selector.specificity()
 
 
 class Attrib:

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -311,6 +311,8 @@ class TestCssselect(unittest.TestCase):
         assert specificity(":is(.foo, #bar)") == (1, 0, 0)
         assert specificity(":is(:hover, :visited)") == (0, 1, 0)
         assert specificity(":where(:hover, :visited)") == (0, 0, 0)
+        assert specificity("foo:is(.bar, #baz)") == (1, 0, 1)
+        assert specificity("foo:where(.bar, #baz)") == (0, 0, 1)
 
         assert specificity("foo:empty") == (0, 1, 1)
         assert specificity("foo:before") == (0, 0, 2)


### PR DESCRIPTION
Fixes #136.

This keeps the specificity from the selector before `:is()` and `:where()`. The `:is()` argument specificity is still added using the most specific argument, while `:where()` only contributes zero for its own argument list.

Checked with:
- `uv run --with pytest --with lxml pytest tests/test_cssselect.py::TestCssselect::test_specificity -q`
- `uv run --with pytest --with lxml --with sybil pytest tests -q`
- `uv run --with ruff ruff check cssselect/parser.py tests/test_cssselect.py`
- `uv run --with tox tox -e typing -- cssselect/parser.py tests/test_cssselect.py`