### PR TITLE
Fix: Replace surrogates in Unicode code points

### DIFF
--- a/cssselect/parser.py
+++ b/cssselect/parser.py
@@ -919,7 +919,7 @@ _replace_simple = operator.methodcaller("group", 1)
 
 def _replace_unicode(match: re.Match[str]) -> str:
     codepoint = int(match.group(1), 16)
-    if codepoint > sys.maxunicode:
+    if codepoint > sys.maxunicode or 0xD800 <= codepoint <= 0xDFFF:
         codepoint = 0xFFFD
     return chr(codepoint)
 

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -213,7 +213,7 @@ class TestCssselect(unittest.TestCase):
         assert parse_one("*") == ("Element[*]", None)
         assert parse_one(":empty") == ("Pseudo[Element[*]:empty]", None)
         assert parse_one(":scope") == ("Pseudo[Element[*]:scope]", None)
-        assert parse_one(":\\DDDD") == ('Pseudo[Element[*]:\ufffd]', None)
+        assert parse_one(":\\DDDD") == ("Pseudo[Element[*]:\ufffd]", None)
 
         # Special cases for CSS 2.1 pseudo-elements
         assert parse_one(":BEfore") == ("Element[*]", "before")

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -213,6 +213,7 @@ class TestCssselect(unittest.TestCase):
         assert parse_one("*") == ("Element[*]", None)
         assert parse_one(":empty") == ("Pseudo[Element[*]:empty]", None)
         assert parse_one(":scope") == ("Pseudo[Element[*]:scope]", None)
+        assert parse_one(":\\DDDD") == ('Pseudo[Element[*]:\ufffd]', None)
 
         # Special cases for CSS 2.1 pseudo-elements
         assert parse_one(":BEfore") == ("Element[*]", "before")


### PR DESCRIPTION
This PR fixes a bug discovered by oss-fuzz. You can find the reproducer [here](https://issues.oss-fuzz.com/issues/423198191).

The program crashes because surrogates in Unicode escape sequences are just ignored.
That leads to a crash when the string containing surrogates is passed to `ascii_lower`:
```python
def ascii_lower(string: str) -> str:
    """Lower-case, but only in the ASCII range."""
    return string.encode("utf8").lower().decode("utf8")
```
```
UnicodeEncodeError: 'utf-8' codec can't encode character '\udddd' in position 3: surrogates not allowed
```
This PR fixes this bug, by replacing surrogates with U+FFFD REPLACEMENT CHARACTER (�) in the `_replace_unicode` function. This is corresponding to the [spec](https://drafts.csswg.org/css-syntax/#consume-escaped-code-point).

It also adds a reproducing test case. Also the oss-fuzz [reproducer](https://issues.oss-fuzz.com/issues/423198191) is patched with this PR.
