### PR TITLE
Fix specificity of :is()/:where() with a leading selector (#136)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+*   Fixed the specificity computation for ``:is()`` and ``:where()`` when they
+    follow another selector (e.g. ``div:is(.foo)``): the specificity of the
+    leading selector was being dropped (:issue:`136`).
+
 Version 1.4.0
 -------------
 

--- a/cssselect/parser.py
+++ b/cssselect/parser.py
@@ -315,7 +315,11 @@ class Matching:
         return f"{self.selector.canonical()}:is({args_str})"
 
     def specificity(self) -> tuple[int, int, int]:
-        return max(x.specificity() for x in self.selector_list)
+        # :is() contributes the specificity of its most specific argument, added
+        # to the specificity of the selector it is attached to.
+        a1, b1, c1 = self.selector.specificity()
+        a2, b2, c2 = max(x.specificity() for x in self.selector_list)
+        return a1 + a2, b1 + b2, c1 + c2
 
 
 class SpecificityAdjustment:
@@ -341,7 +345,9 @@ class SpecificityAdjustment:
         return f"{self.selector.canonical()}:where({args_str})"
 
     def specificity(self) -> tuple[int, int, int]:
-        return 0, 0, 0
+        # :where() itself always adds zero specificity, but the selector it is
+        # attached to still contributes its own.
+        return self.selector.specificity()
 
 
 class Attrib:

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -312,6 +312,14 @@ class TestCssselect(unittest.TestCase):
         assert specificity(":is(:hover, :visited)") == (0, 1, 0)
         assert specificity(":where(:hover, :visited)") == (0, 0, 0)
 
+        # A selector preceding :is()/:where() contributes its own specificity
+        # (gh-136).
+        assert specificity("div:is(.foo)") == (0, 1, 1)
+        assert specificity(".a:is(#b)") == (1, 1, 0)
+        assert specificity("div.cls:is(#a, .b)") == (1, 1, 1)
+        assert specificity("div:where(.foo)") == (0, 0, 1)
+        assert specificity("#id:where(div, .c)") == (1, 0, 0)
+
         assert specificity("foo:empty") == (0, 1, 1)
         assert specificity("foo:before") == (0, 0, 2)
         assert specificity("foo::before") == (0, 0, 2)


### PR DESCRIPTION
## Summary

Fixes #136. The `Matching` (`:is`) and `SpecificityAdjustment` (`:where`) nodes represent `selector:is(...)` / `selector:where(...)`, but their `specificity()` ignored the leading `selector`:

```python
parse("div:is(.foo)")[0].specificity()    # (0, 1, 0)  -> should be (0, 1, 1)
parse("div:where(.foo)")[0].specificity()  # (0, 0, 0)  -> should be (0, 0, 1)
parse(".a:is(#b)")[0].specificity()        # (1, 0, 0)  -> should be (1, 1, 0)
```

`:is()` should add the specificity of its most specific argument **to that of the selector it is attached to**, and `:where()` adds zero from its arguments but the attached selector still counts. `Negation` (`:not`) and `Relation` (`:has`) already combine the leading selector this way; `Matching`/`SpecificityAdjustment` didn't.

## Fix

- `Matching.specificity()`: add `self.selector.specificity()` to the max of the argument list.
- `SpecificityAdjustment.specificity()`: return `self.selector.specificity()` (arguments contribute 0).

(Cross-checked against `symfony/css-selector`, the PHP port, which has the same structure — see the linked Symfony PR in the issue.)

## Tests

- Extended `test_specificity` with leading-selector cases; they fail on `master` and pass here. Existing bare-`:is`/`:where` assertions are unchanged.
- Full suite passes (16); `ruff` clean; changelog updated.

*Disclosure: prepared with AI assistance; reviewed and verified locally.*
