### PR TITLE
Fix some :is(), :where() and :matches() bugs.

### DIFF
--- a/cssselect/parser.py
+++ b/cssselect/parser.py
@@ -739,8 +739,7 @@ def parse_simple_selector_arguments(stream: TokenStream) -> list[Tree]:
             )
         stream.skip_whitespace()
         next_ = stream.next()
-        if next_ in (("EOF", None), ("DELIM", ",")):
-            stream.next()
+        if next_ == ("DELIM", ","):
             stream.skip_whitespace()
             arguments.append(result)
         elif next_ == ("DELIM", ")"):

--- a/cssselect/xpath.py
+++ b/cssselect/xpath.py
@@ -83,11 +83,13 @@ class XPathExpr:
             # We weren't doing a test anyway
             return
         prefix, colon, local = self.element.partition(":")
-        if colon and is_safe_name(prefix) and (local == "*" or is_safe_name(local)):
-            # A prefixed name like "ns:f" or "ns:*" (from the CSS "ns|f" or
-            # "ns|*"): name() would compare against the prefix as literally
-            # written in the document, bypassing the XPath prefix mapping,
-            # so use a node test instead.
+        if is_safe_name(prefix) and (not colon or local == "*" or is_safe_name(local)):
+            # A node test, not a name() comparison: name() returns the
+            # qualified name as written in the document, which would bypass
+            # the XPath prefix mapping for a prefixed name like "ns:f" or
+            # "ns:*" (from the CSS "ns|f" or "ns|*"), and would match
+            # elements in a default namespace for an unprefixed name (which
+            # the node test emitted for a bare "f" selector does not).
             self.add_condition(f"self::{self.element}")
         else:
             self.add_condition(

--- a/cssselect/xpath.py
+++ b/cssselect/xpath.py
@@ -82,7 +82,15 @@ class XPathExpr:
         if self.element == "*":
             # We weren't doing a test anyway
             return
-        self.add_condition(f"name() = {GenericTranslator.xpath_literal(self.element)}")
+        if self.element.endswith(":*") and is_safe_name(self.element[:-2]):
+            # A namespace-prefix wildcard like "ns:*" (from the CSS "ns|*"):
+            # name() is never the literal string "ns:*", so compare with a
+            # node test instead.
+            self.add_condition(f"self::{self.element}")
+        else:
+            self.add_condition(
+                f"name() = {GenericTranslator.xpath_literal(self.element)}"
+            )
         self.element = "*"
 
     def add_star_prefix(self) -> None:

--- a/cssselect/xpath.py
+++ b/cssselect/xpath.py
@@ -37,7 +37,7 @@ from cssselect.parser import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterable
 
     # typing.Self requires Python 3.11
     from typing_extensions import Self
@@ -331,22 +331,37 @@ class GenericTranslator:
         return method(xpath, right)
 
     def xpath_matching(self, matching: Matching) -> XPathExpr:
-        xpath = self.xpath(matching.selector)
-        exprs = [self.xpath(selector) for selector in matching.selector_list]
-        for e in exprs:
-            e.add_name_test()
-            if e.condition:
-                xpath.add_condition(e.condition, "or")
-        return xpath
+        return self._xpath_add_selector_list_condition(
+            self.xpath(matching.selector), matching.selector_list
+        )
 
     def xpath_specificityadjustment(self, matching: SpecificityAdjustment) -> XPathExpr:
-        xpath = self.xpath(matching.selector)
-        exprs = [self.xpath(selector) for selector in matching.selector_list]
-        for e in exprs:
+        return self._xpath_add_selector_list_condition(
+            self.xpath(matching.selector), matching.selector_list
+        )
+
+    def _xpath_add_selector_list_condition(
+        self, xpath: XPathExpr, selector_list: Iterable[Tree]
+    ) -> XPathExpr:
+        """Add a condition matching any selector of the list
+        (for :is() and :where())."""
+        condition = ""
+        for e in (self.xpath(selector) for selector in selector_list):
+            if e.path:
+                # E.g. a :has() argument: it translates to a path, which
+                # cannot be embedded into a predicate of the outer expression.
+                raise ExpressionError(
+                    ":has() is not supported inside :is() and :where()"
+                )
             e.add_name_test()
-            if e.condition:
-                xpath.add_condition(e.condition, "or")
-        return xpath
+            if not e.condition:
+                # This argument matches any element, so the whole selector
+                # list does too: it adds no condition.
+                return xpath
+            condition = (
+                f"({condition}) or ({e.condition})" if condition else e.condition
+            )
+        return xpath.add_condition(condition)
 
     def xpath_function(self, function: Function) -> XPathExpr:
         """Translate a functional pseudo-class."""

--- a/cssselect/xpath.py
+++ b/cssselect/xpath.py
@@ -82,10 +82,12 @@ class XPathExpr:
         if self.element == "*":
             # We weren't doing a test anyway
             return
-        if self.element.endswith(":*") and is_safe_name(self.element[:-2]):
-            # A namespace-prefix wildcard like "ns:*" (from the CSS "ns|*"):
-            # name() is never the literal string "ns:*", so compare with a
-            # node test instead.
+        prefix, colon, local = self.element.partition(":")
+        if colon and is_safe_name(prefix) and (local == "*" or is_safe_name(local)):
+            # A prefixed name like "ns:f" or "ns:*" (from the CSS "ns|f" or
+            # "ns|*"): name() would compare against the prefix as literally
+            # written in the document, bypassing the XPath prefix mapping,
+            # so use a node test instead.
             self.add_condition(f"self::{self.element}")
         else:
             self.add_condition(
@@ -449,7 +451,12 @@ class GenericTranslator:
             safe = safe and bool(is_safe_name(selector.namespace))
         xpath = self.xpathexpr_cls(element=element)
         if not safe:
-            xpath.add_name_test()
+            # Not usable as an XPath name test (e.g. an escaped identifier
+            # like di\a0 v): compare the serialized name instead. Done here
+            # rather than through add_name_test(), which would mistake a ":"
+            # inside such a name for a namespace prefix separator.
+            xpath.add_condition(f"name() = {self.xpath_literal(element)}")
+            xpath.element = "*"
         return xpath
 
     # CombinedSelector: dispatch by combinator

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -36,10 +36,12 @@ from cssselect import (
 from cssselect.parser import (
     Function,
     FunctionalPseudoElement,
+    Matching,
     PseudoElement,
     Token,
     parse_series,
     tokenize,
+    unescape_ident,
 )
 from cssselect.xpath import XPathExpr
 
@@ -485,7 +487,11 @@ class TestCssselect(unittest.TestCase):
         assert get_error(":lang(fr)") is None
         assert get_error(":lang(fr") == ("Expected an argument, got <EOF at 8>")
         assert get_error(':contains("foo') == ("Unclosed string at 10")
+        # A raw newline terminates the string match without closing it.
+        assert get_error('[a="b\nc"]') == ("Invalid string at 3")
         assert get_error("foo!") == ("Expected selector, got <DELIM '!' at 3>")
+        # An unclosed comment runs to the end of the input and is ignored.
+        assert get_error("a /* unclosed") is None
 
         # Mis-placed pseudo-elements
         assert get_error("a:before:empty") == (
@@ -498,6 +504,9 @@ class TestCssselect(unittest.TestCase):
             "Got pseudo-element ::before inside :not() at 12"
         )
         assert get_error(":not(:not(a))") == ("Got nested :not()")
+        # :not() only takes a single simple selector as an argument
+        assert get_error(":not(a b)") == ("Expected ')', got <S ' ' at 6>")
+        assert get_error(":not(a, b)") == ("Expected ')', got <DELIM ',' at 6>")
         # A :not() inside :is()/:where()/:matches() is not a nested :not()
         # and gets its own message
         assert get_error(":is(:not(a))") == (
@@ -591,6 +600,9 @@ class TestCssselect(unittest.TestCase):
             "e[@foo and substring(@foo, string-length(@foo)-2) = 'bar']"
         )
         assert xpath('e[foo*="bar"]') == ("e[@foo and contains(@foo, 'bar')]")
+        assert xpath("e[foo!=bar]") == ("e[not(@foo) or @foo != 'bar']")
+        # An empty value for != only requires the attribute to differ.
+        assert xpath("e[foo!='']") == ("e[@foo != '']")
         assert xpath('e[hreflang|="en"]') == (
             "e[@hreflang and (@hreflang = 'en' or starts-with(@hreflang, 'en-'))]"
         )
@@ -817,10 +829,57 @@ class TestCssselect(unittest.TestCase):
             xpath(":lorem(ipsum)")
         with pytest.raises(ExpressionError):
             xpath("::lorem-ipsum")
+        with pytest.raises(ExpressionError, match=r":contains\(\)"):
+            xpath(":contains(1)")
+        with pytest.raises(ExpressionError, match=r":lang\(\)"):
+            xpath(":lang(1)")
         with pytest.raises(TypeError):
             GenericTranslator().css_to_xpath(4)  # type: ignore[arg-type]
         with pytest.raises(TypeError):
             GenericTranslator().selector_to_xpath("foo")  # type: ignore[arg-type]
+
+    def test_translation_customization_api(self) -> None:
+        # XPathExpr.add_star_prefix() constrains the context to a single
+        # parent; it is part of the customization API rather than used by
+        # the built-in translation.
+        expr = XPathExpr("foo")
+        expr.add_star_prefix()
+        assert expr.path == "foo*/"
+
+        # join() drops a redundant "*/" star prefix from the joined path.
+        left = XPathExpr("a")
+        star = XPathExpr()
+        star.add_star_prefix()
+        assert star.path == "*/"
+        left.join(" ", star)
+        # The "*/" of ``star`` is omitted; only ``str(left) + combiner`` remains.
+        assert left.path == "a* "
+
+        # An unknown parsed-tree type has no xpath_<type>() handler.
+        class Bogus:
+            pass
+
+        with pytest.raises(ExpressionError, match="Bogus is not supported"):
+            GenericTranslator().xpath(Bogus())  # type: ignore[arg-type]
+
+        # lower_case_attribute_values is an extension point: when enabled,
+        # attribute values are lower-cased in the generated XPath.
+        class LowerValues(GenericTranslator):
+            lower_case_attribute_values = True
+
+        assert LowerValues().css_to_xpath("[Foo=BAR]", prefix="") == "*[@Foo = 'bar']"
+
+        # A member of an :is()/:where() selector list that translates to a
+        # path (rather than a predicate) cannot be embedded in the outer
+        # predicate and is rejected. The parser does not currently produce
+        # such an argument, so build the Matching node directly.
+        base = parse("x")[0].parsed_tree
+        combined = parse("a b")[0].parsed_tree
+        matching = Matching(base, [combined])
+        with pytest.raises(
+            ExpressionError, match=r"not supported inside :is\(\) and :where\(\)"
+        ):
+            GenericTranslator().xpath(matching)
 
     def test_add_name_test(self) -> None:
         # Directly exercise XPathExpr.add_name_test(), part of the
@@ -888,6 +947,11 @@ class TestCssselect(unittest.TestCase):
         assert css_to_xpath("*[aval=\"'\\20\r\n '\"]") == (
             """descendant-or-self::*[@aval = "'  '"]"""
         )
+        # A code point beyond the Unicode range is replaced with U+FFFD.
+        assert css_to_xpath(r"\110000") == ("descendant-or-self::*[name() = '\ufffd']")
+        # unescape_ident() resolves both unicode and simple escapes.
+        assert unescape_ident(r"\41 B") == "AB"
+        assert unescape_ident(r"\-foo") == "-foo"
 
     def test_xpath_pseudo_elements(self) -> None:
         class CustomTranslator(GenericTranslator):
@@ -1029,6 +1093,8 @@ class TestCssselect(unittest.TestCase):
         assert series("5") == (0, 5)
         assert series("foo") is None
         assert series("n+") is None
+        # String tokens are not allowed in a series.
+        assert series('"foo"') is None
         # ASCII-case-insensitive
         assert series("2N+1") == (2, 1)
         assert series("EVEN") == (2, 0)
@@ -1062,6 +1128,13 @@ class TestCssselect(unittest.TestCase):
             "eighth",
         ]
         assert langid(":lang(es)") == []
+
+        # The HTML translator requires a string or ident argument too.
+        with pytest.raises(ExpressionError, match=r":lang\(\)"):
+            HTMLTranslator().css_to_xpath(":lang(1)")
+        # The XHTML variant keeps element and attribute names case-sensitive.
+        assert HTMLTranslator(xhtml=True).css_to_xpath("A") == ("descendant-or-self::A")
+        assert HTMLTranslator().css_to_xpath("A") == ("descendant-or-self::a")
 
     def test_argument_types(self) -> None:
         class CustomTranslator(GenericTranslator):

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -589,12 +589,17 @@ class TestCssselect(unittest.TestCase):
         # :matches() is an alias of :is()
         assert xpath("e:matches(foo, bar)") == "e[(name() = 'foo') or (name() = 'bar')]"
         assert xpath("e:matches(.a, .b)") == xpath("e:is(.a, .b)")
-        # A namespace-prefix wildcard is a node test, not a literal name
+        # A prefixed name is a node test resolved through the namespace
+        # prefix mapping, not a literal name() comparison
         assert xpath("ns|*") == "ns:*"
         assert xpath("e:is(ns|*)") == "e[self::ns:*]"
         assert xpath("e:where(ns|*)") == "e[self::ns:*]"
         assert xpath("*:not(ns|*)") == "*[not(self::ns:*)]"
-        assert xpath("e:is(ns|f)") == "e[name() = 'ns:f']"
+        assert xpath("e:is(ns|f)") == "e[self::ns:f]"
+        assert xpath("*:not(ns|f)") == "*[not(self::ns:f)]"
+        assert xpath("x + ns|f") == (
+            "x/following-sibling::*[(self::ns:f) and (position() = 1)]"
+        )
 
         # Invalid characters in XPath element names
         assert xpath(r"di\a0 v") == ("*[name() = 'di v']")  # di\xa0v
@@ -1129,7 +1134,12 @@ class TestCssselect(unittest.TestCase):
         ]
 
     def test_select_with_namespace(self) -> None:
-        document = etree.XML('<r xmlns:n="urn:x"><n:a id="ns-el"/><b id="plain"/></r>')
+        # The document prefix (n) deliberately differs from the selector
+        # prefix (ns): matching must go through the namespace mapping, not
+        # compare the prefixed name as a string.
+        document = etree.XML(
+            '<r xmlns:n="urn:x"><n:a id="ns-el"/><b id="plain"/><n:c id="ns-el2"/></r>'
+        )
         css_to_xpath = GenericTranslator().css_to_xpath
 
         def pcss(css: str) -> list[str]:
@@ -1139,9 +1149,14 @@ class TestCssselect(unittest.TestCase):
             )
             return [element.get("id", "nil") for element in items]
 
-        assert pcss("ns|*") == ["ns-el"]
-        assert pcss(":is(ns|*)") == ["ns-el"]
+        assert pcss("ns|*") == ["ns-el", "ns-el2"]
+        assert pcss(":is(ns|*)") == ["ns-el", "ns-el2"]
         assert pcss("*:not(ns|*)") == ["nil", "plain"]
+        assert pcss("ns|a") == ["ns-el"]
+        assert pcss(":is(ns|a)") == ["ns-el"]
+        assert pcss(":is(b, ns|a)") == ["ns-el", "plain"]
+        assert pcss("*:not(ns|a)") == ["nil", "plain", "ns-el2"]
+        assert pcss("b + ns|c") == ["ns-el2"]
 
     def test_select_shakespeare(self) -> None:
         document = html.document_fromstring(HTML_SHAKESPEARE)

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -170,9 +170,12 @@ class TestCssselect(unittest.TestCase):
             "SpecificityAdjustment[Element[*]:where(Pseudo[Element[*]:hover],"
             " Pseudo[Element[*]:visited])]"
         ]
-        assert parse_many(":is(.foo, .bar)", ":is(.foo,.bar)", ":is(.foo ,.bar)") == [
-            "Matching[Element[*]:is(Class[Element[*].foo], Class[Element[*].bar])]"
-        ]
+        assert parse_many(
+            ":is(.foo, .bar)",
+            ":is(.foo,.bar)",
+            ":is(.foo ,.bar)",
+            ":matches(.foo, .bar)",
+        ) == ["Matching[Element[*]:is(Class[Element[*].foo], Class[Element[*].bar])]"]
         assert parse_many(":where(.foo, .bar)", ":where(.foo,.bar)") == [
             "SpecificityAdjustment[Element[*]:where(Class[Element[*].foo],"
             " Class[Element[*].bar])]"
@@ -583,6 +586,15 @@ class TestCssselect(unittest.TestCase):
             xpath("e:is(:has(f))")
         with pytest.raises(ExpressionError):
             xpath("e:where(:has(f))")
+        # :matches() is an alias of :is()
+        assert xpath("e:matches(foo, bar)") == "e[(name() = 'foo') or (name() = 'bar')]"
+        assert xpath("e:matches(.a, .b)") == xpath("e:is(.a, .b)")
+        # A namespace-prefix wildcard is a node test, not a literal name
+        assert xpath("ns|*") == "ns:*"
+        assert xpath("e:is(ns|*)") == "e[self::ns:*]"
+        assert xpath("e:where(ns|*)") == "e[self::ns:*]"
+        assert xpath("*:not(ns|*)") == "*[not(self::ns:*)]"
+        assert xpath("e:is(ns|f)") == "e[name() = 'ns:f']"
 
         # Invalid characters in XPath element names
         assert xpath(r"di\a0 v") == ("*[name() = 'di v']")  # di\xa0v
@@ -1070,7 +1082,7 @@ class TestCssselect(unittest.TestCase):
             "second-li",
         ]
         assert pcss("a:is(#name-anchor, #tag-anchor)") == ["name-anchor", "tag-anchor"]
-        assert pcss(":is(.c)") == ["first-ol", "third-li", "fourth-li"]
+        assert pcss(":is(.c)", ":matches(.c)") == ["first-ol", "third-li", "fourth-li"]
         assert pcss("li:is(*, .c)") == [
             "first-li",
             "second-li",
@@ -1115,6 +1127,21 @@ class TestCssselect(unittest.TestCase):
             "checkbox-checked",
             "checkbox-disabled-checked",
         ]
+
+    def test_select_with_namespace(self) -> None:
+        document = etree.XML('<r xmlns:n="urn:x"><n:a id="ns-el"/><b id="plain"/></r>')
+        css_to_xpath = GenericTranslator().css_to_xpath
+
+        def pcss(css: str) -> list[str]:
+            items = typing.cast(
+                "list[etree._Element]",
+                document.xpath(css_to_xpath(css), namespaces={"ns": "urn:x"}),
+            )
+            return [element.get("id", "nil") for element in items]
+
+        assert pcss("ns|*") == ["ns-el"]
+        assert pcss(":is(ns|*)") == ["ns-el"]
+        assert pcss("*:not(ns|*)") == ["nil", "plain"]
 
     def test_select_shakespeare(self) -> None:
         document = html.document_fromstring(HTML_SHAKESPEARE)

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -170,6 +170,13 @@ class TestCssselect(unittest.TestCase):
             "SpecificityAdjustment[Element[*]:where(Pseudo[Element[*]:hover],"
             " Pseudo[Element[*]:visited])]"
         ]
+        assert parse_many(":is(.foo, .bar)", ":is(.foo,.bar)", ":is(.foo ,.bar)") == [
+            "Matching[Element[*]:is(Class[Element[*].foo], Class[Element[*].bar])]"
+        ]
+        assert parse_many(":where(.foo, .bar)", ":where(.foo,.bar)") == [
+            "SpecificityAdjustment[Element[*]:where(Class[Element[*].foo],"
+            " Class[Element[*].bar])]"
+        ]
         assert parse_many("td ~ th") == ["CombinedSelector[Element[td] ~ Element[th]]"]
         assert parse_many(":scope > foo") == [
             "CombinedSelector[Pseudo[Element[*]:scope] > Element[foo]]"
@@ -425,6 +432,10 @@ class TestCssselect(unittest.TestCase):
         assert get_error(":where(a b)") == (
             "Expected an argument, got <IDENT 'b' at 9>"
         )
+        assert get_error(":is(a") == ("Expected an argument, got <EOF at 5>")
+        assert get_error(":is(a,") == ("Expected selector, got <EOF at 6>")
+        assert get_error(":is(a,)") == ("Expected selector, got <DELIM ')' at 6>")
+        assert get_error(":where(a") == ("Expected an argument, got <EOF at 8>")
         assert get_error(":scope > div :scope header") == (
             'Got immediate child pseudo-element ":scope" not at the start of a selector'
         )
@@ -557,6 +568,21 @@ class TestCssselect(unittest.TestCase):
         )
         assert xpath("e:where(foo)") == "e[name() = 'foo']"
         assert xpath("e:where(foo, bar)") == "e[(name() = 'foo') or (name() = 'bar')]"
+        assert xpath("e:is(.a,.b)") == xpath("e:is(.a, .b)")
+        assert xpath("e:is(*, .foo)") == "e"
+        assert xpath("e:where(*, foo)") == "e"
+        assert xpath("e.foo:is(.a, .b)") == (
+            "e[(@class and contains("
+            "concat(' ', normalize-space(@class), ' '), ' foo ')) and "
+            "((@class and contains("
+            "concat(' ', normalize-space(@class), ' '), ' a ')) or "
+            "(@class and contains("
+            "concat(' ', normalize-space(@class), ' '), ' b ')))]"
+        )
+        with pytest.raises(ExpressionError):
+            xpath("e:is(:has(f))")
+        with pytest.raises(ExpressionError):
+            xpath("e:where(:has(f))")
 
         # Invalid characters in XPath element names
         assert xpath(r"di\a0 v") == ("*[name() = 'di v']")  # di\xa0v
@@ -1039,9 +1065,23 @@ class TestCssselect(unittest.TestCase):
         ]
         assert pcss("link:has(*)") == []
         assert pcss("ol:has(div)") == ["first-ol"]
-        assert pcss(":is(#first-li, #second-li)") == ["first-li", "second-li"]
+        assert pcss(":is(#first-li, #second-li)", ":is(#first-li,#second-li)") == [
+            "first-li",
+            "second-li",
+        ]
         assert pcss("a:is(#name-anchor, #tag-anchor)") == ["name-anchor", "tag-anchor"]
         assert pcss(":is(.c)") == ["first-ol", "third-li", "fourth-li"]
+        assert pcss("li:is(*, .c)") == [
+            "first-li",
+            "second-li",
+            "third-li",
+            "fourth-li",
+            "fifth-li",
+            "sixth-li",
+            "seventh-li",
+        ]
+        assert pcss("ol.a:is(.nonexistent)") == []
+        assert pcss("ol.a:is(.b, .nonexistent)") == ["first-ol"]
         assert pcss("ol.a.b.c > li.c:nth-child(3)") == ["third-li"]
 
         # Invalid characters in XPath element names, should not crash

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -788,7 +788,7 @@ class TestCssselect(unittest.TestCase):
         # :scope, alone and in a compound selector
         assert xpath(":scope") == "*[position() = 1]"
         assert xpath("*:scope") == "*[position() = 1]"
-        assert xpath("div:scope") == "*[(name() = 'div') and (position() = 1)]"
+        assert xpath("div:scope") == "*[(self::div) and (position() = 1)]"
         assert xpath(".foo:scope") == (
             "*[(@class and contains("
             "concat(' ', normalize-space(@class), ' '), ' foo ')) "

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -638,6 +638,29 @@ class TestCssselect(unittest.TestCase):
         with pytest.raises(TypeError):
             GenericTranslator().selector_to_xpath("foo")  # type: ignore[arg-type]
 
+    def test_add_name_test(self) -> None:
+        # Directly exercise XPathExpr.add_name_test(), part of the
+        # customization API: translation never feeds it a name unusable in
+        # a node test (xpath_element() compares those with name() itself),
+        # but a subclass can, and then the name() fallback must be used.
+        def name_test(element: str) -> str:
+            xpath = XPathExpr(element=element)
+            xpath.add_name_test()
+            return str(xpath)
+
+        # Safe names become node tests, resolved through the namespace
+        # prefix mapping when prefixed.
+        assert name_test("f") == "*[self::f]"
+        assert name_test("ns:f") == "*[self::ns:f]"
+        assert name_test("ns:*") == "*[self::ns:*]"
+        # Names not usable in a node test fall back to a name() comparison,
+        # whether the local name or the prefix is at fault.
+        assert name_test("di v") == "*[name() = 'di v']"
+        assert name_test("ns:di v") == "*[name() = 'ns:di v']"
+        assert name_test("di v:f") == "*[name() = 'di v:f']"
+        # The universal selector needs no test at all.
+        assert name_test("*") == "*"
+
     def test_unicode(self) -> None:
         css = ".a\xc1b"
         xpath = GenericTranslator().css_to_xpath(css)

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -560,7 +560,7 @@ class TestCssselect(unittest.TestCase):
         assert xpath("e f") == ("e/descendant-or-self::*/f")
         assert xpath("e > f") == ("e/f")
         assert xpath("e + f") == (
-            "e/following-sibling::*[(name() = 'f') and (position() = 1)]"
+            "e/following-sibling::*[(self::f) and (position() = 1)]"
         )
         assert xpath("e ~ f") == ("e/following-sibling::f")
         assert xpath("e ~ f:nth-child(3)") == (
@@ -569,8 +569,8 @@ class TestCssselect(unittest.TestCase):
         assert xpath("div#container p") == (
             "div[@id = 'container']/descendant-or-self::*/p"
         )
-        assert xpath("e:where(foo)") == "e[name() = 'foo']"
-        assert xpath("e:where(foo, bar)") == "e[(name() = 'foo') or (name() = 'bar')]"
+        assert xpath("e:where(foo)") == "e[self::foo]"
+        assert xpath("e:where(foo, bar)") == "e[(self::foo) or (self::bar)]"
         assert xpath("e:is(.a,.b)") == xpath("e:is(.a, .b)")
         assert xpath("e:is(*, .foo)") == "e"
         assert xpath("e:where(*, foo)") == "e"
@@ -587,10 +587,14 @@ class TestCssselect(unittest.TestCase):
         with pytest.raises(ExpressionError):
             xpath("e:where(:has(f))")
         # :matches() is an alias of :is()
-        assert xpath("e:matches(foo, bar)") == "e[(name() = 'foo') or (name() = 'bar')]"
+        assert xpath("e:matches(foo, bar)") == "e[(self::foo) or (self::bar)]"
         assert xpath("e:matches(.a, .b)") == xpath("e:is(.a, .b)")
-        # A prefixed name is a node test resolved through the namespace
-        # prefix mapping, not a literal name() comparison
+        # A type selector in predicate position is a node test, not a
+        # literal name() comparison: a prefixed name must resolve through
+        # the namespace prefix mapping, and an unprefixed name must not
+        # match elements in a default namespace (a bare "f" does not).
+        assert xpath("e:is(f)") == "e[self::f]"
+        assert xpath("*:not(f)") == "*[not(self::f)]"
         assert xpath("ns|*") == "ns:*"
         assert xpath("e:is(ns|*)") == "e[self::ns:*]"
         assert xpath("e:where(ns|*)") == "e[self::ns:*]"
@@ -1157,6 +1161,28 @@ class TestCssselect(unittest.TestCase):
         assert pcss(":is(b, ns|a)") == ["ns-el", "plain"]
         assert pcss("*:not(ns|a)") == ["nil", "plain", "ns-el2"]
         assert pcss("b + ns|c") == ["ns-el2"]
+
+    def test_select_with_default_namespace(self) -> None:
+        # A bare "f" translates to an unprefixed XPath node test, which
+        # only matches elements in *no* namespace, so it cannot see
+        # elements in a default namespace. Predicate positions (:is(),
+        # :not(), "+") must agree with that, not compare name() (which
+        # would match such elements by their unprefixed qualified name).
+        document = etree.XML('<r xmlns="urn:d"><x id="x"/><f id="dns-f"/></r>')
+        css_to_xpath = GenericTranslator().css_to_xpath
+
+        def pcss(css: str) -> list[str]:
+            items = typing.cast(
+                "list[etree._Element]", document.xpath(css_to_xpath(css))
+            )
+            return [element.get("id", "nil") for element in items]
+
+        assert pcss("f") == []
+        assert pcss(":is(f)") == []
+        assert pcss("x + f") == []
+        # ... and since "f" does not match the default-namespaced <f>,
+        # :not(f) must not exclude it.
+        assert pcss("*:not(f)") == ["nil", "x", "dns-f"]
 
     def test_select_shakespeare(self) -> None:
         document = html.document_fromstring(HTML_SHAKESPEARE)


### PR DESCRIPTION
1. `:is(a,b)` mangle the argument after a comma not followed by whitespace
2. `:is(*, X)` drops the universal argument and becomes over-restrictive
3. `:is(:has(X))` translates to a never-matching garbage predicate
4. Unclosed `:is(` escapes as `RuntimeError`, not `SelectorSyntaxError`
5. `:matches()` isn't tested
6. A `ns|*` argument of `:is()`/`:where()`/`:not()` becomes a never-matching literal name test (fixes #18)
7. `name()`-literal comparisons don't match node-test semantics under a default namespace

Also applies to `:matches` (alias for `:is`) and for `:where` (shares the implementation with `:is`).

Found and fixed by an LLM, all test cases validated manually.