### PR TITLE
Support ID selectors inside :has()

### DIFF
--- a/cssselect/parser.py
+++ b/cssselect/parser.py
@@ -771,7 +771,7 @@ def parse_relative_selector(stream: TokenStream) -> tuple[Token, Selector]:
             # else it would be a descendant combinator, which is not
             # supported in :has() arguments.
             seen_whitespace = True
-        elif next_.type == "IDENT" or next_.is_delim(".", "*"):
+        elif next_.type in ("IDENT", "HASH") or next_.is_delim(".", "*"):
             if seen_whitespace:
                 raise SelectorSyntaxError(f"Expected an argument, got {next_}")
             subselector_tokens.append(next_)

--- a/tests/test_cssselect.py
+++ b/tests/test_cssselect.py
@@ -190,6 +190,12 @@ class TestCssselect(unittest.TestCase):
         assert parse_many("div:has(~ div.foo)") == [
             "Relation[Element[div]:has(~ Selector[Class[Element[div].foo]])]"
         ]
+        assert parse_many("div:has(#foo)") == [
+            "Relation[Element[div]:has(Selector[Hash[Element[*]#foo]])]"
+        ]
+        assert parse_many("div:has(> a#foo.bar)") == [
+            "Relation[Element[div]:has(> Selector[Class[Hash[Element[a]#foo].bar]])]"
+        ]
         assert parse_many("div:is(.foo, #bar)") == [
             "Matching[Element[div]:is(Class[Element[*].foo], Hash[Element[*]#bar])]"
         ]
@@ -363,6 +369,7 @@ class TestCssselect(unittest.TestCase):
         assert specificity(":has(foo)") == (0, 0, 1)
         assert specificity(":has(.foo)") == (0, 1, 0)
         assert specificity(":has(> foo)") == (0, 0, 1)
+        assert specificity(":has(#foo)") == (1, 0, 0)
 
         assert specificity(":is(.foo, #bar)") == (1, 0, 0)
         assert specificity(":is(:hover, :visited)") == (0, 1, 0)
@@ -428,6 +435,7 @@ class TestCssselect(unittest.TestCase):
         css2css(":has(~ foo)")
         css2css(":has(+ foo)")
         css2css("div:has(> div.foo)")
+        css2css("div:has(> #foo)")
         css2css(":is(#bar, .foo)")
         css2css(":is(:focused, :visited)")
         css2css(":where(:focused, :visited)")
@@ -625,6 +633,7 @@ class TestCssselect(unittest.TestCase):
         assert get_error(":has()") == ("Expected selector, got <EOF at 5>")
         assert get_error(":has(a b)") == ("Expected an argument, got <IDENT 'b' at 7>")
         assert get_error(":has(a .b)") == ("Expected an argument, got <DELIM '.' at 7>")
+        assert get_error(":has(a #b)") == ("Expected an argument, got <HASH 'b' at 7>")
         # '-' is not a valid relative combinator
         assert get_error(":has(- p)") == ("Expected an argument, got <DELIM '-' at 5>")
         # Strings and numbers are not selectors
@@ -745,6 +754,8 @@ class TestCssselect(unittest.TestCase):
             "e[./*[@class and contains("
             "concat(' ', normalize-space(@class), ' '), ' bar ')]]"
         )
+        assert xpath("e:has(> #bar)") == "e[./*[@id = 'bar']]"
+        assert xpath("e:has(#bar)") == "e[descendant::*[@id = 'bar']]"
         assert xpath("e:has(~ f.bar)") == (
             "e[following-sibling::f[@class and contains("
             "concat(' ', normalize-space(@class), ' '), ' bar ')]]"


### PR DESCRIPTION
`parse_relative_selector()` only accepts `IDENT`, `.`, and `*` tokens in a `:has()` argument, so any ID selector raises:

```python
>>> parse("div:has(> #foo)")
SelectorSyntaxError: Expected an argument, got <HASH 'foo' at 10>
```

This works in browsers, which implement the full relative-selector grammar.

This PR adds `HASH` to the accepted token types in the argument loop. No changes are needed in the translation layer—the token reparse and XPath translation already handle `Hash` nodes, escaped identifiers included:

```python
>>> HTMLTranslator().css_to_xpath(r"div:has(> #foo\.bar)")
"descendant-or-self::div[./*[@id = 'foo.bar']]"
```

Tests added for parsing, specificity, `repr` round-trip, XPath translation, and the error case (`:has(a #b)` still rejects the descendant combinator).

**Downstream report:** `D4Vinci/Scrapling#433`
